### PR TITLE
add additional stuff to subscriptions

### DIFF
--- a/backend/app/models/subscription.py
+++ b/backend/app/models/subscription.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Float, Date, ForeignKey
+from sqlalchemy import Column, Integer, String, Float, Date, ForeignKey, Boolean, Text
 from sqlalchemy.orm import relationship
 
 from app.database import Base
@@ -14,6 +14,12 @@ class Subscription(Base):
     billing_cycle = Column(String, nullable=False)  # "monthly" or "yearly"
     next_payment_date = Column(Date, nullable=False)
     category = Column(String, nullable=True)
+    
+    is_pinned = Column(Boolean, default=False, nullable=False)
+    is_favourite = Column(Boolean, default=False, nullable=False)
+    is_active = Column(Boolean, default=True, nullable=False)
+    cancelled_at = Column(Date, nullable=True)   
+    notes = Column(Text, nullable=True)
 
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
 

--- a/backend/app/models/subscription.py
+++ b/backend/app/models/subscription.py
@@ -14,11 +14,11 @@ class Subscription(Base):
     billing_cycle = Column(String, nullable=False)  # "monthly" or "yearly"
     next_payment_date = Column(Date, nullable=False)
     category = Column(String, nullable=True)
-    
+
     is_pinned = Column(Boolean, default=False, nullable=False)
     is_favourite = Column(Boolean, default=False, nullable=False)
     is_active = Column(Boolean, default=True, nullable=False)
-    cancelled_at = Column(Date, nullable=True)   
+    cancelled_at = Column(Date, nullable=True)
     notes = Column(Text, nullable=True)
 
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)

--- a/backend/app/routers/subscriptions.py
+++ b/backend/app/routers/subscriptions.py
@@ -2,13 +2,17 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from app.database import get_db
-from app.schemas.subscription import SubscriptionCreate, SubscriptionOut, SubscriptionUpdate
+from app.schemas.subscription import (
+    SubscriptionCreate,
+    SubscriptionOut,
+    SubscriptionUpdate,
+)
 from app.services.subscription_service import (
     create_subscription,
     get_user_subscriptions,
     update_subscription,
     cancel_subscription,
-    delete_one_inactive,  
+    delete_one_inactive,
     delete_all_inactive,
     reactivate_subscription,
 )
@@ -32,6 +36,7 @@ def get_subs(
     current_user=Depends(get_current_user),
 ):
     return get_user_subscriptions(db, current_user.id)
+
 
 @router.patch("/{subscription_id}", response_model=SubscriptionOut)
 def update_sub(
@@ -57,6 +62,7 @@ def cancel_sub(
         raise HTTPException(status_code=404, detail="Subscription not found")
     return sub
 
+
 @router.patch("/{subscription_id}/reactivate", response_model=SubscriptionOut)
 def reactivate_sub(
     subscription_id: int,
@@ -68,6 +74,7 @@ def reactivate_sub(
         raise HTTPException(status_code=404, detail="Subscription not found")
     return sub
 
+
 @router.delete("/inactive/all", status_code=200)
 def delete_all_inactive_subs(
     db: Session = Depends(get_db),
@@ -75,6 +82,7 @@ def delete_all_inactive_subs(
 ):
     delete_all_inactive(db, current_user.id)
     return {"deleted": "all inactive"}
+
 
 @router.delete("/{subscription_id}", status_code=200)
 def delete_one_sub(
@@ -86,5 +94,3 @@ def delete_one_sub(
     if not result:
         raise HTTPException(status_code=404, detail="Inactive subscription not found")
     return {"deleted": 1}
-
-

--- a/backend/app/routers/subscriptions.py
+++ b/backend/app/routers/subscriptions.py
@@ -1,11 +1,16 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from app.database import get_db
-from app.schemas.subscription import SubscriptionCreate, SubscriptionOut
+from app.schemas.subscription import SubscriptionCreate, SubscriptionOut, SubscriptionUpdate
 from app.services.subscription_service import (
     create_subscription,
     get_user_subscriptions,
+    update_subscription,
+    cancel_subscription,
+    delete_one_inactive,  
+    delete_all_inactive,
+    reactivate_subscription,
 )
 from app.dependencies.auth import get_current_user
 
@@ -27,3 +32,59 @@ def get_subs(
     current_user=Depends(get_current_user),
 ):
     return get_user_subscriptions(db, current_user.id)
+
+@router.patch("/{subscription_id}", response_model=SubscriptionOut)
+def update_sub(
+    subscription_id: int,
+    data: SubscriptionUpdate,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    sub = update_subscription(db, subscription_id, current_user.id, data)
+    if not sub:
+        raise HTTPException(status_code=404, detail="Subscription not found")
+    return sub
+
+
+@router.patch("/{subscription_id}/cancel", response_model=SubscriptionOut)
+def cancel_sub(
+    subscription_id: int,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    sub = cancel_subscription(db, subscription_id, current_user.id)
+    if not sub:
+        raise HTTPException(status_code=404, detail="Subscription not found")
+    return sub
+
+@router.patch("/{subscription_id}/reactivate", response_model=SubscriptionOut)
+def reactivate_sub(
+    subscription_id: int,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    sub = reactivate_subscription(db, subscription_id, current_user.id)
+    if not sub:
+        raise HTTPException(status_code=404, detail="Subscription not found")
+    return sub
+
+@router.delete("/inactive/all", status_code=200)
+def delete_all_inactive_subs(
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    delete_all_inactive(db, current_user.id)
+    return {"deleted": "all inactive"}
+
+@router.delete("/{subscription_id}", status_code=200)
+def delete_one_sub(
+    subscription_id: int,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    result = delete_one_inactive(db, subscription_id, current_user.id)
+    if not result:
+        raise HTTPException(status_code=404, detail="Inactive subscription not found")
+    return {"deleted": 1}
+
+

--- a/backend/app/schemas/subscription.py
+++ b/backend/app/schemas/subscription.py
@@ -13,7 +13,10 @@ class SubscriptionCreate(BaseModel):
     is_active: bool = True
     notes: str | None = None
 
-class SubscriptionUpdate(BaseModel): #allows partial update (pin, favourite, cancel, notes)
+
+class SubscriptionUpdate(
+    BaseModel
+):  # allows partial update (pin, favourite, cancel, notes)
     name: str | None = None
     price: float | None = None
     billing_cycle: str | None = None
@@ -23,6 +26,7 @@ class SubscriptionUpdate(BaseModel): #allows partial update (pin, favourite, can
     is_favourite: bool | None = None
     is_active: bool | None = None
     notes: str | None = None
+
 
 class SubscriptionOut(BaseModel):
     id: int
@@ -36,7 +40,6 @@ class SubscriptionOut(BaseModel):
     is_active: bool
     cancelled_at: date | None
     notes: str | None
-    
+
     class Config:
         from_attributes = True
-

--- a/backend/app/schemas/subscription.py
+++ b/backend/app/schemas/subscription.py
@@ -8,7 +8,21 @@ class SubscriptionCreate(BaseModel):
     billing_cycle: str
     next_payment_date: date
     category: str | None = None
+    is_pinned: bool = False
+    is_favourite: bool = False
+    is_active: bool = True
+    notes: str | None = None
 
+class SubscriptionUpdate(BaseModel): #allows partial update (pin, favourite, cancel, notes)
+    name: str | None = None
+    price: float | None = None
+    billing_cycle: str | None = None
+    next_payment_date: date | None = None
+    category: str | None = None
+    is_pinned: bool | None = None
+    is_favourite: bool | None = None
+    is_active: bool | None = None
+    notes: str | None = None
 
 class SubscriptionOut(BaseModel):
     id: int
@@ -16,7 +30,13 @@ class SubscriptionOut(BaseModel):
     price: float
     billing_cycle: str
     next_payment_date: date
-    category: str
-
+    category: str | None
+    is_pinned: bool
+    is_favourite: bool
+    is_active: bool
+    cancelled_at: date | None
+    notes: str | None
+    
     class Config:
         from_attributes = True
+

--- a/backend/app/services/subscription_service.py
+++ b/backend/app/services/subscription_service.py
@@ -79,7 +79,7 @@ def auto_clear_old_inactive(db: Session, user_id: int):
         db.query(Subscription)
         .filter(
             Subscription.user_id == user_id,
-            Subscription.is_active == False,
+            Subscription.is_active.is_(False),
             Subscription.cancelled_at <= cutoff,
         )
         .all()
@@ -95,7 +95,7 @@ def delete_one_inactive(db: Session, subscription_id: int, user_id: int):
         .filter(
             Subscription.id == subscription_id,
             Subscription.user_id == user_id,
-            Subscription.is_active == False,
+            Subscription.is_active.is_(False),
         )
         .first()
     )
@@ -109,7 +109,7 @@ def delete_one_inactive(db: Session, subscription_id: int, user_id: int):
 def delete_all_inactive(db: Session, user_id: int):
     inactive = (
         db.query(Subscription)
-        .filter(Subscription.user_id == user_id, Subscription.is_active == False)
+        .filter(Subscription.user_id == user_id, Subscription.is_active.is_(False))
         .all()
     )
     for sub in inactive:

--- a/backend/app/services/subscription_service.py
+++ b/backend/app/services/subscription_service.py
@@ -1,6 +1,6 @@
 from sqlalchemy.orm import Session
 from app.models.subscription import Subscription
-
+from datetime import date, timedelta
 
 def create_subscription(db: Session, user_id: int, data):
     subscription = Subscription(
@@ -10,6 +10,10 @@ def create_subscription(db: Session, user_id: int, data):
         next_payment_date=data.next_payment_date,
         category=data.category,
         user_id=user_id,
+        is_pinned=data.is_pinned,
+        is_favourite=data.is_favourite,
+        is_active=data.is_active,
+        notes=data.notes,
     )
 
     db.add(subscription)
@@ -20,4 +24,60 @@ def create_subscription(db: Session, user_id: int, data):
 
 
 def get_user_subscriptions(db: Session, user_id: int):
-    return db.query(Subscription).filter(Subscription.user_id == user_id).all()
+    auto_clear_old_inactive(db, user_id)
+    return db.query(Subscription).filter(Subscription.user_id == user_id).order_by(Subscription.is_pinned.desc(),Subscription.is_active.desc(),Subscription.next_payment_date.asc()).all()
+
+def update_subscription(db: Session, subscription_id: int, user_id: int, data):
+    sub = db.query(Subscription).filter(Subscription.id == subscription_id, Subscription.user_id == user_id).first()
+    if not sub:
+        return None
+    
+    for field, value in data.model_dump(exclude_unset=True).items(): #only updates fields that were provided
+        setattr(sub, field, value)
+    db.commit()
+    db.refresh(sub)
+    return sub
+
+def cancel_subscription(db: Session, subscription_id: int, user_id: int):  # keep in DB, just mark inactive
+    sub = db.query(Subscription).filter(Subscription.id == subscription_id, Subscription.user_id == user_id).first()
+    if not sub:
+        return None
+    sub.is_active = False
+    sub.cancelled_at = date.today()
+    db.commit()
+    db.refresh(sub)
+    return sub
+
+def auto_clear_old_inactive(db: Session, user_id: int):
+    cutoff = date.today() - timedelta(days=30)
+    old_inactive = db.query(Subscription).filter(Subscription.user_id == user_id, Subscription.is_active == False, Subscription.cancelled_at <= cutoff).all()
+    for sub in old_inactive:
+        db.delete(sub)
+    db.commit()
+
+
+def delete_one_inactive(db: Session, subscription_id: int, user_id: int):
+    sub = db.query(Subscription).filter(Subscription.id == subscription_id, Subscription.user_id == user_id, Subscription.is_active == False).first()
+    if not sub:
+        return None
+    db.delete(sub)
+    db.commit()
+    return True
+
+
+def delete_all_inactive(db: Session, user_id: int):
+    inactive = db.query(Subscription).filter(Subscription.user_id == user_id, Subscription.is_active == False).all()
+    for sub in inactive:
+        db.delete(sub)
+    db.commit()
+
+
+def reactivate_subscription(db: Session, subscription_id: int, user_id: int):
+    sub = db.query(Subscription).filter(Subscription.id == subscription_id, Subscription.user_id == user_id).first()
+    if not sub:
+        return None
+    sub.is_active = True
+    sub.cancelled_at = None  # clear cancel date
+    db.commit()
+    db.refresh(sub)
+    return sub

--- a/backend/app/services/subscription_service.py
+++ b/backend/app/services/subscription_service.py
@@ -2,6 +2,7 @@ from sqlalchemy.orm import Session
 from app.models.subscription import Subscription
 from datetime import date, timedelta
 
+
 def create_subscription(db: Session, user_id: int, data):
     subscription = Subscription(
         name=data.name,
@@ -25,21 +26,44 @@ def create_subscription(db: Session, user_id: int, data):
 
 def get_user_subscriptions(db: Session, user_id: int):
     auto_clear_old_inactive(db, user_id)
-    return db.query(Subscription).filter(Subscription.user_id == user_id).order_by(Subscription.is_pinned.desc(),Subscription.is_active.desc(),Subscription.next_payment_date.asc()).all()
+    return (
+        db.query(Subscription)
+        .filter(Subscription.user_id == user_id)
+        .order_by(
+            Subscription.is_pinned.desc(),
+            Subscription.is_active.desc(),
+            Subscription.next_payment_date.asc(),
+        )
+        .all()
+    )
+
 
 def update_subscription(db: Session, subscription_id: int, user_id: int, data):
-    sub = db.query(Subscription).filter(Subscription.id == subscription_id, Subscription.user_id == user_id).first()
+    sub = (
+        db.query(Subscription)
+        .filter(Subscription.id == subscription_id, Subscription.user_id == user_id)
+        .first()
+    )
     if not sub:
         return None
-    
-    for field, value in data.model_dump(exclude_unset=True).items(): #only updates fields that were provided
+
+    for field, value in data.model_dump(
+        exclude_unset=True
+    ).items():  # only updates fields that were provided
         setattr(sub, field, value)
     db.commit()
     db.refresh(sub)
     return sub
 
-def cancel_subscription(db: Session, subscription_id: int, user_id: int):  # keep in DB, just mark inactive
-    sub = db.query(Subscription).filter(Subscription.id == subscription_id, Subscription.user_id == user_id).first()
+
+def cancel_subscription(
+    db: Session, subscription_id: int, user_id: int
+):  # keep in DB, just mark inactive
+    sub = (
+        db.query(Subscription)
+        .filter(Subscription.id == subscription_id, Subscription.user_id == user_id)
+        .first()
+    )
     if not sub:
         return None
     sub.is_active = False
@@ -48,16 +72,33 @@ def cancel_subscription(db: Session, subscription_id: int, user_id: int):  # kee
     db.refresh(sub)
     return sub
 
+
 def auto_clear_old_inactive(db: Session, user_id: int):
     cutoff = date.today() - timedelta(days=30)
-    old_inactive = db.query(Subscription).filter(Subscription.user_id == user_id, Subscription.is_active == False, Subscription.cancelled_at <= cutoff).all()
+    old_inactive = (
+        db.query(Subscription)
+        .filter(
+            Subscription.user_id == user_id,
+            Subscription.is_active == False,
+            Subscription.cancelled_at <= cutoff,
+        )
+        .all()
+    )
     for sub in old_inactive:
         db.delete(sub)
     db.commit()
 
 
 def delete_one_inactive(db: Session, subscription_id: int, user_id: int):
-    sub = db.query(Subscription).filter(Subscription.id == subscription_id, Subscription.user_id == user_id, Subscription.is_active == False).first()
+    sub = (
+        db.query(Subscription)
+        .filter(
+            Subscription.id == subscription_id,
+            Subscription.user_id == user_id,
+            Subscription.is_active == False,
+        )
+        .first()
+    )
     if not sub:
         return None
     db.delete(sub)
@@ -66,14 +107,22 @@ def delete_one_inactive(db: Session, subscription_id: int, user_id: int):
 
 
 def delete_all_inactive(db: Session, user_id: int):
-    inactive = db.query(Subscription).filter(Subscription.user_id == user_id, Subscription.is_active == False).all()
+    inactive = (
+        db.query(Subscription)
+        .filter(Subscription.user_id == user_id, Subscription.is_active == False)
+        .all()
+    )
     for sub in inactive:
         db.delete(sub)
     db.commit()
 
 
 def reactivate_subscription(db: Session, subscription_id: int, user_id: int):
-    sub = db.query(Subscription).filter(Subscription.id == subscription_id, Subscription.user_id == user_id).first()
+    sub = (
+        db.query(Subscription)
+        .filter(Subscription.id == subscription_id, Subscription.user_id == user_id)
+        .first()
+    )
     if not sub:
         return None
     sub.is_active = True


### PR DESCRIPTION
## Overview

I updated the subscription system with new fields: pin, favourite, notes, active/cancel state, and cancel date. 

Inactive subscriptions logic:

When a user cancels a subscription, it is not deleted - it is marked as inactive and we store the cancel date. 

After that, the user has 3 options within 30 days: 

- Reactivate it 
- Delete it manually (single) 
- Delete all cancelled subscriptions 

After 30 days, inactive subscriptions are automatically removed when subscriptions are loaded. 

## Changes



## Related issues

Closes #21