### PR TITLE
Origin/feature/fixing annual subscriptions

### DIFF
--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -458,7 +458,7 @@ function Dashboard() {
                             />
                         </div>
 
-                        <div className="mt-6 space-y-4">
+                        <div className="mt-6 space-y-4 overflow-visible">
                             {loading ? (
                                 <p className="text-gray-400">Ładowanie subskrypcji...</p>
                             ) : error ? (
@@ -473,7 +473,7 @@ function Dashboard() {
                                     return (
                                         <div
                                             key={subscription.id}
-                                            className={`rounded-3xl border border-gray-800 bg-gray-900/90 p-4 sm:p-5 relative ${!subscription.is_active ? 'opacity-50' : ''}`}
+                                            className={`rounded-3xl border border-gray-800 bg-gray-900/90 p-4 sm:p-5 relative overflow-visible ${!subscription.is_active ? 'opacity-50' : ''} ${showDeleteConfirm === subscription.id ? 'z-50' : ''}`}
                                         >
                                             <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                                                 <div className="flex items-center gap-4 flex-1">
@@ -522,7 +522,7 @@ function Dashboard() {
                                                         ⋯
                                                     </button>
                                                     {showDeleteConfirm === subscription.id && (
-                                                        <div className="absolute right-0 top-full mt-2 bg-gray-800 border border-gray-600 rounded-lg p-2 z-10 min-w-[120px]">
+                                                        <div className="absolute right-0 top-full mt-2 bg-gray-800 border border-gray-600 rounded-lg p-2 z-50 min-w-[120px] shadow-xl">
                                                             <button
                                                                 onClick={() => handleEditSubscription(subscription)}
                                                                 className="block w-full text-left px-3 py-2 hover:bg-gray-700 text-white rounded"

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -270,9 +270,23 @@ function Dashboard() {
         }
     };
 
+    const formatSubscriptionPrice = (subscription) => {
+        const price = Number(subscription.price) || 0;
+        return subscription.billing_cycle === 'yearly'
+            ? `${price.toFixed(2)} PLN/rok`
+            : `${price.toFixed(2)} PLN/mies.`;
+    };
+
     const activeSubscriptions = subscriptions.filter((item) => item.is_active !== false);
-    const totalMonthly = activeSubscriptions.reduce((sum, item) => sum + (Number(item.price) || 0), 0);
-    const totalYearly = totalMonthly * 12;
+    const totalMonthly = activeSubscriptions.reduce((sum, item) => {
+        const price = Number(item.price) || 0;
+        return sum + (item.billing_cycle === 'yearly' ? price / 12 : price);
+    }, 0);
+
+    const totalYearly = activeSubscriptions.reduce((sum, item) => {
+        const price = Number(item.price) || 0;
+        return sum + (item.billing_cycle === 'yearly' ? price : price * 12);
+    }, 0);
 
     const sortedSubscriptions = [...subscriptions].sort((a, b) => {
         // First, sort by is_favourite (true first)
@@ -496,7 +510,7 @@ function Dashboard() {
                                                 </div>
                                                 <div className="text-right">
                                                     <p className="text-xl font-semibold text-white">
-                                                        {subscription.price.toFixed(2)} PLN/mies.
+                                                        {formatSubscriptionPrice(subscription)}
                                                     </p>
                                                     <p className="mt-1 text-sm text-gray-400">Następna płatność: {subscription.next_payment_date}</p>
                                                 </div>


### PR DESCRIPTION
## Overview

Fixed bugs in budget calculations regarding yearly subscriptions, improved price formatting, and resolved a UI layout/z-index clipping bug with the dropdown menu on the Dashboard cards.

## Changes

Financial Calculations & Formatting
Accurate Totals: Fixed a bug where yearly subscriptions were messing up the summary. Integrated conditional checking (billing_cycle === 'yearly') to properly calculate totals:

totalMonthly: Divides yearly prices by 12 before adding them to the sum.

totalYearly: Multiplies monthly prices by 12 before adding them to the sum.

Dynamic Helper: Added formatSubscriptionPrice to dynamically output values with suffixes based on the cycle (e.g., PLN/rok or PLN/mies.), replacing the hardcoded PLN/mies. string.
UI Fixes (Dropdown & Z-Index)
Overflow & Clipping Fix: Added overflow-visible to both the subscription cards and their outer container. This ensures that the absolute-positioned delete confirmation dropdown doesn't get cut off by container bounds.

Z-Index Layering: Dynamicized the z-index classes. Increased the dropdown to z-50 and conditionally injected z-50 onto the active card wrapper when its confirmation menu is open (showDeleteConfirm === subscription.id), keeping it safely layered above neighboring cards. Added a nicer shadow-xl for better contrast.

## Related issues

Closes #