### PR TITLE
Fix pinned subscriptions sorting

### DIFF
--- a/SCOPE.md
+++ b/SCOPE.md
@@ -14,7 +14,7 @@ mógł:
 
 - [x] Moduł rejestracji, logowania użytkownika oraz w pełni działający system odzyskiwania hasła
 - [ ] Główny pulpit (Dashboard) zawierający powitanie z imieniem użytkownika, łączne koszty w ujęciu miesięcznym i rocznym oraz interaktywny diagram kołowy z danymi w dwóch trybach.
-- [x] Pełne zarządzanie subskrypcjami: dodawanie (ręczne lub z katalogu), usuwanie, wygaszanie oraz zaawansowana edycja (m.in. przypinanie – pinned, oznaczanie jako ulubione, dodawanie notatek oraz edycja wprowadzonych danych).
+- [x] Pełne zarządzanie subskrypcjami: dodawanie (ręczne lub z katalogu), usuwanie, wygaszanie oraz zaawansowana edycja (m.in. oznaczanie jako ulubione, dodawanie notatek oraz edycja wprowadzonych danych).
 - [x] Widok listy subskrypcji wyposażony w mechanizmy filtrowania, sortowania oraz wyszukiwania konkretnych wydatków.
 - [ ] Widok kalendarza pozwalający na śledzenie dat najbliższych płatności.
 - [x] System powiadomień o zbliżających się płatnościach: wizualne alerty wewnątrz aplikacji oraz powiadomienia wysyłane na adres e-mail użytkownika.
@@ -49,7 +49,7 @@ pomiędzy różnymi użytkownikami
     + diagram kołowy (dwa tryby)
     + dodawanie/usuwanie subskrypcji
 * Sebastian Gęborys:
-    + edycja subskrybcji (pinned, favourite, notes, dane)
+    + edycja subskrybcji (favourite, notes, dane)
     + ustawienia
 * Bartosz Mroczek:
     + lista subskrybcji (oraz filtrowanie, sortowanie, wyszukiwanie)

--- a/backend/app/models/subscription.py
+++ b/backend/app/models/subscription.py
@@ -15,7 +15,6 @@ class Subscription(Base):
     next_payment_date = Column(Date, nullable=False)
     category = Column(String, nullable=True)
 
-    is_pinned = Column(Boolean, default=False, nullable=False)
     is_favourite = Column(Boolean, default=False, nullable=False)
     is_active = Column(Boolean, default=True, nullable=False)
     cancelled_at = Column(Date, nullable=True)

--- a/backend/app/schemas/subscription.py
+++ b/backend/app/schemas/subscription.py
@@ -8,7 +8,6 @@ class SubscriptionCreate(BaseModel):
     billing_cycle: str
     next_payment_date: date
     category: str | None = None
-    is_pinned: bool = False
     is_favourite: bool = False
     is_active: bool = True
     notes: str | None = None
@@ -16,13 +15,12 @@ class SubscriptionCreate(BaseModel):
 
 class SubscriptionUpdate(
     BaseModel
-):  # allows partial update (pin, favourite, cancel, notes)
+):  # allows partial update (favourite, cancel, notes)
     name: str | None = None
     price: float | None = None
     billing_cycle: str | None = None
     next_payment_date: date | None = None
     category: str | None = None
-    is_pinned: bool | None = None
     is_favourite: bool | None = None
     is_active: bool | None = None
     notes: str | None = None
@@ -35,7 +33,6 @@ class SubscriptionOut(BaseModel):
     billing_cycle: str
     next_payment_date: date
     category: str | None
-    is_pinned: bool
     is_favourite: bool
     is_active: bool
     cancelled_at: date | None

--- a/backend/app/schemas/subscription.py
+++ b/backend/app/schemas/subscription.py
@@ -13,9 +13,7 @@ class SubscriptionCreate(BaseModel):
     notes: str | None = None
 
 
-class SubscriptionUpdate(
-    BaseModel
-):  # allows partial update (favourite, cancel, notes)
+class SubscriptionUpdate(BaseModel):  # allows partial update (favourite, cancel, notes)
     name: str | None = None
     price: float | None = None
     billing_cycle: str | None = None

--- a/backend/app/services/subscription_service.py
+++ b/backend/app/services/subscription_service.py
@@ -11,7 +11,6 @@ def create_subscription(db: Session, user_id: int, data):
         next_payment_date=data.next_payment_date,
         category=data.category,
         user_id=user_id,
-        is_pinned=data.is_pinned,
         is_favourite=data.is_favourite,
         is_active=data.is_active,
         notes=data.notes,
@@ -30,7 +29,6 @@ def get_user_subscriptions(db: Session, user_id: int):
         db.query(Subscription)
         .filter(Subscription.user_id == user_id)
         .order_by(
-            Subscription.is_pinned.desc(),
             Subscription.is_active.desc(),
             Subscription.next_payment_date.asc(),
         )

--- a/docs/diagrams/DBS/DBScheme.txt
+++ b/docs/diagrams/DBS/DBScheme.txt
@@ -34,7 +34,6 @@ CREATE TABLE subscriptions (
 
     category VARCHAR NULL,
 
-    is_pinned BOOLEAN NOT NULL DEFAULT FALSE,
     is_favourite BOOLEAN NOT NULL DEFAULT FALSE,
     is_active BOOLEAN NOT NULL DEFAULT TRUE,
 

--- a/docs/diagrams/FunctionHierarchy/HierarchiaFunkcjiKodDoMiro.csv
+++ b/docs/diagrams/FunctionHierarchy/HierarchiaFunkcjiKodDoMiro.csv
@@ -12,9 +12,8 @@ Analiza kosztów,analiza.kosztow@smartsub.pl,Funkcja,modul.dashboard@smartsub.pl
 13. Kalendarz,funkcja.13@smartsub.pl,Funkcja,modul.dashboard@smartsub.pl
 12. Lista subskrypcji,funkcja.12@smartsub.pl,Funkcja,modul.subskrypcji@smartsub.pl
 10. Dodawanie/usuwanie subskrypcji,funkcja.10@smartsub.pl,Funkcja,modul.subskrypcji@smartsub.pl
-11. Edycja subskrypcji (pinned/favourite/notes/dane),funkcja.11@smartsub.pl,Funkcja,modul.subskrypcji@smartsub.pl
+11. Edycja subskrypcji (favourite/notes/dane),funkcja.11@smartsub.pl,Funkcja,modul.subskrypcji@smartsub.pl
 Zarządzanie notatkami,notes@smartsub.pl,Funkcja,funkcja.11@smartsub.pl
-Przypinanie (Pinned),pinned@smartsub.pl,Funkcja,funkcja.11@smartsub.pl
 Oznaczanie jako ulubione (Favourite),favourite@smartsub.pl,Funkcja,funkcja.11@smartsub.pl
 Autoryzacja i bezpieczeństwo,autoryzacja.sekcja@smartsub.pl,Funkcja,modul.autoryzacji@smartsub.pl
 1. Logowanie,funkcja.1@smartsub.pl,Funkcja,autoryzacja.sekcja@smartsub.pl

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -47,7 +47,6 @@ function Dashboard() {
         billing_cycle: 'monthly',
         next_payment_date: '',
         category: '',
-        is_pinned: false,
         is_favourite: false,
         notes: '',
     });
@@ -174,7 +173,6 @@ function Dashboard() {
             billing_cycle: 'monthly',
             next_payment_date: '',
             category: '',
-            is_pinned: false,
             is_favourite: false,
             notes: '',
             selectedPredefined: 'custom',
@@ -206,7 +204,6 @@ function Dashboard() {
                 billing_cycle: formData.billing_cycle,
                 next_payment_date: new Date(formData.next_payment_date).toISOString().split('T')[0],
                 category: formData.category,
-                is_pinned: formData.is_pinned,
                 is_favourite: formData.is_favourite,
                 notes: formData.notes,
             };
@@ -232,7 +229,6 @@ function Dashboard() {
             billing_cycle: subscription.billing_cycle,
             next_payment_date: subscription.next_payment_date,
             category: subscription.category,
-            is_pinned: subscription.is_pinned ?? false,
             is_favourite: subscription.is_favourite ?? false,
             notes: subscription.notes ?? '',
             selectedPredefined: isPredefined ? subscription.name : 'custom',
@@ -294,7 +290,6 @@ function Dashboard() {
                 billing_cycle: formData.billing_cycle,
                 next_payment_date: new Date(formData.next_payment_date).toISOString().split('T')[0],
                 category: formData.category,
-                is_pinned: formData.is_pinned,
                 is_favourite: formData.is_favourite,
                 notes: formData.notes,
             };
@@ -359,11 +354,7 @@ function Dashboard() {
     }, 0);
 
     const sortedSubscriptions = [...subscriptions].sort((a, b) => {
-        // First, sort by is_pinned (true first)
-        const pinnedDiff = (b.is_pinned ? 1 : 0) - (a.is_pinned ? 1 : 0);
-        if (pinnedDiff !== 0) return pinnedDiff;
-
-        // Then, sort by is_favourite (true first)
+        // First, sort by is_favourite (true first)
         const favDiff = (b.is_favourite ? 1 : 0) - (a.is_favourite ? 1 : 0);
         if (favDiff !== 0) return favDiff;
 
@@ -995,32 +986,19 @@ function Dashboard() {
                                 />
                             </div>
 
-                            <div className="grid gap-4 sm:grid-cols-2">
-                                <label className="flex items-center gap-3 text-gray-300">
-                                    <input
-                                        type="checkbox"
-                                        name="is_pinned"
-                                        checked={formData.is_pinned}
-                                        onChange={handleFormChange}
-                                        className="accent-blue-500"
-                                    />
-                                    Przypięte
-                                </label>
-                                <label className="flex items-center gap-3 text-gray-300">
-                                    <input
-                                        type="checkbox"
-                                        name="is_favourite"
-                                        checked={formData.is_favourite}
-                                        onChange={handleFormChange}
-                                        className="accent-blue-500"
-                                    />
+                            <div>
+                                <label className="block text-sm font-medium text-gray-300 mb-2">
                                     Ulubione
                                 </label>
+                                <button
+                                    type="button"
+                                    onClick={() => setFormData(prev => ({ ...prev, is_favourite: !prev.is_favourite }))}
+                                    title={formData.is_favourite ? 'Usuń z ulubionych' : 'Dodaj do ulubionych'}
+                                    className={`text-2xl transition ${formData.is_favourite ? 'text-yellow-400' : 'text-gray-500 hover:text-yellow-300'}`}
+                                >
+                                    {formData.is_favourite ? '★' : '☆'}
+                                </button>
                             </div>
-
-
-
-
 
                             {formError && (
                                 <p className="text-red-400 text-sm">{formError}</p>

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -359,7 +359,11 @@ function Dashboard() {
     }, 0);
 
     const sortedSubscriptions = [...subscriptions].sort((a, b) => {
-        // First, sort by is_favourite (true first)
+        // First, sort by is_pinned (true first)
+        const pinnedDiff = (b.is_pinned ? 1 : 0) - (a.is_pinned ? 1 : 0);
+        if (pinnedDiff !== 0) return pinnedDiff;
+
+        // Then, sort by is_favourite (true first)
         const favDiff = (b.is_favourite ? 1 : 0) - (a.is_favourite ? 1 : 0);
         if (favDiff !== 0) return favDiff;
 


### PR DESCRIPTION
## What changed

Added `is_pinned` as the highest priority in frontend subscription sorting.

## Why

Pinned subscriptions were saved correctly, but they were not always displayed at the top because frontend sorting prioritized favourites and active subscriptions before the selected sort mode, but did not include pinned state.

## Sorting order now

1. pinned subscriptions
2. favourite subscriptions
3. active subscriptions
4. selected sort mode: name, price, or date